### PR TITLE
Resolving the latest rsan's warnings

### DIFF
--- a/stan/includes/dlm.stan
+++ b/stan/includes/dlm.stan
@@ -6,7 +6,7 @@ matrix make_symmetric_matrix(matrix x) {
 
 int dlm_filter_return_size(int r, int p) {
   int ret;
-  ret <- 2 * p * p + 2 * p + 2 * r;
+  ret = 2 * p * p + 2 * p + 2 * r;
   return ret;
 }
 
@@ -16,7 +16,7 @@ matrix to_matrix_wdim(vector v, int r, int c) {
   matrix[r, c] res;
   for (j in 1:c) {
     for (i in 1:r) {
-      res[i, j] <- v[(j - 1) * r + i];
+      res[i, j] = v[(j - 1) * r + i];
     }
   }
   return res;
@@ -95,49 +95,49 @@ vector[] dlm_filter(int n, int r, int p,
   //   print("miss = ", miss);
 
   
-  m <- m0;
-  C <- C0;
+  m = m0;
+  C = C0;
   // print("t=", 0, ", m=", m);
   // print("t=", 0, ", C=", C);
 
-  res[1] <- rep_vector(0.0, dlm_filter_return_size(r, p));
+  res[1] = rep_vector(0.0, dlm_filter_return_size(r, p));
   for(i in 1:p) {
-    res[1, i] <- m[i];
+    res[1, i] = m[i];
   }
-  C_vec <- to_vector(C);
+  C_vec = to_vector(C);
   for (i in 1:(p * p)) {
-    res[1, p + i] <- C_vec[i];
+    res[1, p + i] = C_vec[i];
   }
   for (t in 1:n) {
     // PREDICT STATES
     // one step ahead predictive distribion of p(\theta_t | y_{1:(t-1)})
-    a <- g[t] + G[t] * m;
-    R <- quad_form(C, G[t] ') + W[t];
-    m <- a;
-    C <- R;
+    a = g[t] + G[t] * m;
+    R = quad_form(C, G[t] ') + W[t];
+    m = a;
+    C = R;
     // print("t=", t, ", a=", a);
     // print("t=", t, ", R=", R);
     for (j in 1:r) {
       if (int_step(miss[t, j])) {
-        e[j] <- 0.0;
-        Q_inv[j] <- 0.0;
+        e[j] = 0.0;
+        Q_inv[j] = 0.0;
       } else {
         // print("t = ", t, ", predict");
         // PREDICT OBS
         // one step ahead predictive distribion of p(y_t | y_{1:(t-1)})
-        Fj <- row(F[t], j) ';
-        f <- b[t, j] + dot_product(Fj, m);
-        Q <- quad_form(C, Fj) + V[t, j];
-        Q_inv[j] <- 1.0 / Q;
+        Fj = row(F[t], j) ';
+        f = b[t, j] + dot_product(Fj, m);
+        Q = quad_form(C, Fj) + V[t, j];
+        Q_inv[j] = 1.0 / Q;
         // forecast error
-        e[j] <- y[t, j] - f;
+        e[j] = y[t, j] - f;
         // Kalman gain
-        K <- C * Fj * Q_inv[j];
+        K = C * Fj * Q_inv[j];
         // print("t = ", t, ", filter");
         // FILTER STATES
         // posterior distribution of p(\theta_t | y_{1:t})
-        m <- m + K * e[j];
-        C <- make_symmetric_matrix(C - K * Q * K ');
+        m = m + K * e[j];
+        C = make_symmetric_matrix(C - K * Q * K ');
       }
       // print("t=", t, ", j=", j, ", m=", m);
       // print("t=", t, ", j=", j, ", C=", C);
@@ -146,24 +146,24 @@ vector[] dlm_filter(int n, int r, int p,
       // print(" ");
     }
     for(i in 1:p) {
-      res[t + 1, i] <- m[i];
+      res[t + 1, i] = m[i];
     }
-    C_vec <- to_vector(C);
+    C_vec = to_vector(C);
     for (i in 1:(p * p)) {
-      res[t + 1, p + i] <- C_vec[i];
+      res[t + 1, p + i] = C_vec[i];
     }
     for(i in 1:p) {
-      res[t + 1, p + p * p + i] <- a[i];
+      res[t + 1, p + p * p + i] = a[i];
     }
-    R_vec <- to_vector(R);
+    R_vec = to_vector(R);
     for (i in 1:(p * p)) {
-      res[t + 1, 2 * p + p * p + i] <- R_vec[i];
+      res[t + 1, 2 * p + p * p + i] = R_vec[i];
     }
     for (i in 1:r) {
-      res[t + 1, 2 * p + 2 * p * p + i] <- e[i];
+      res[t + 1, 2 * p + 2 * p * p + i] = e[i];
     }
     for (i in 1:r) {
-      res[t + 1, 2 * p + 2 * p * p + r + i] <- Q_inv[i];
+      res[t + 1, 2 * p + 2 * p * p + r + i] = Q_inv[i];
     }
   }
   return res;
@@ -182,12 +182,12 @@ vector[] dlm_constant_filter(int n, int r, int p,
   matrix[p, p] G_tv[n];
   matrix[p, p] W_tv[n];
 
-  b_tv <- rep_array(b, n);
-  F_tv <- rep_array(F, n);
-  V_tv <- rep_array(V, n);  
-  g_tv <- rep_array(g, n);
-  G_tv <- rep_array(G, n);
-  W_tv <- rep_array(W, n);  
+  b_tv = rep_array(b, n);
+  F_tv = rep_array(F, n);
+  V_tv = rep_array(V, n);  
+  g_tv = rep_array(g, n);
+  G_tv = rep_array(G, n);
+  W_tv = rep_array(W, n);  
   return dlm_filter(n, r, p, y, miss,
                     b_tv, F_tv, V_tv,
                     g_tv, G_tv, W_tv,
@@ -218,34 +218,34 @@ vector[] dlm_loglik(int n, int r, int p,
   // Loglik
   vector[r] loglik[n];
 
-  m <- m0;
-  C <- C0;
+  m = m0;
+  C = C0;
   for (t in 1:n) {
     // PREDICT STATES
     // one step ahead predictive distribion of p(\theta_t | y_{1:(t-1)})
-    a <- g[t] + G[t] * m;
-    R <- quad_form(C, G[t] ') + W[t];
-    m <- a;
-    C <- R;
+    a = g[t] + G[t] * m;
+    R = quad_form(C, G[t] ') + W[t];
+    m = a;
+    C = R;
     for (j in 1:r) {
       if (int_step(miss[t, j])) {
-        loglik[t, j] <- 0.0;
+        loglik[t, j] = 0.0;
       } else {
         // PREDICT OBS
         // one step ahead predictive distribion of p(y_t | y_{1:(t-1)})
-        Fj <- F[t, j] ';
-        f <- b[t, j] + dot_product(Fj, m);
-        Q <- quad_form(C, Fj) + V[t, j];
-        Q_inv <- 1.0 / Q;
+        Fj = F[t, j] ';
+        f = b[t, j] + dot_product(Fj, m);
+        Q = quad_form(C, Fj) + V[t, j];
+        Q_inv = 1.0 / Q;
         // forecast error
-        e <- y[t, j] - f;
+        e = y[t, j] - f;
         // Kalman gain
-        K <- C * Fj * Q_inv;
+        K = C * Fj * Q_inv;
         // FILTER STATES
         // posterior distribution of p(\theta_t | y_{1:t})
-        m <- m + K * e;
-        C <- make_symmetric_matrix(C - K * Q * K ');
-        loglik[t, j] <- - 0.5 * (log(2 * pi()) + log(Q) + e ^ 2 * Q_inv);
+        m = m + K * e;
+        C = make_symmetric_matrix(C - K * Q * K ');
+        loglik[t, j] = - 0.5 * (log(2 * pi()) + log(Q) + e ^ 2 * Q_inv);
       }
     }
   }
@@ -264,12 +264,12 @@ vector[] dlm_constant_loglik(int n, int r, int p,
   matrix[p, p] G_tv[n];
   matrix[p, p] W_tv[n];
 
-  b_tv <- rep_array(b, n);
-  F_tv <- rep_array(F, n);
-  V_tv <- rep_array(V, n);  
-  g_tv <- rep_array(g, n);
-  G_tv <- rep_array(G, n);
-  W_tv <- rep_array(W, n);  
+  b_tv = rep_array(b, n);
+  F_tv = rep_array(F, n);
+  V_tv = rep_array(V, n);  
+  g_tv = rep_array(g, n);
+  G_tv = rep_array(G, n);
+  W_tv = rep_array(W, n);  
   return dlm_loglik(n, r, p, y, miss,
                     b_tv, F_tv, V_tv,
                     g_tv, G_tv, W_tv,
@@ -278,7 +278,7 @@ vector[] dlm_constant_loglik(int n, int r, int p,
 
 
 // directly increment log-probability without returning the individual log-likelihoods
-real dlm_log(int n, int r, int p,
+real dlm_logpdf(int n, int r, int p,
                 vector[] y, int[,] miss,
                 vector[] b, matrix[] F, vector[] V,
                 vector[] g, matrix[] G, matrix[] W,
@@ -286,14 +286,14 @@ real dlm_log(int n, int r, int p,
   vector[r] llall[n];
   vector[n] llobs;
   real ll;
-  llall <- dlm_loglik(n, r, p, y, miss,
+  llall = dlm_loglik(n, r, p, y, miss,
                    b, F, V,
                    g, G, W,
                    m0, C0);
   for (i in 1:n) {
-    llobs[i] <- sum(llall[i]);
+    llobs[i] = sum(llall[i]);
   }
-  ll <- sum(llobs);
+  ll = sum(llobs);
   return ll;
 }
 
@@ -309,13 +309,13 @@ real dlm_constant_log(int n, int r, int p,
   matrix[p, p] G_tv[n];
   matrix[p, p] W_tv[n];
 
-  b_tv <- rep_array(b, n);
-  F_tv <- rep_array(F, n);
-  V_tv <- rep_array(V, n);  
-  g_tv <- rep_array(g, n);
-  G_tv <- rep_array(G, n);
-  W_tv <- rep_array(W, n);  
-  return dlm_log(n, r, p, y, miss,
+  b_tv = rep_array(b, n);
+  F_tv = rep_array(F, n);
+  V_tv = rep_array(V, n);  
+  g_tv = rep_array(g, n);
+  G_tv = rep_array(G, n);
+  W_tv = rep_array(W, n);  
+  return dlm_logpdf(n, r, p, y, miss,
                  b_tv, F_tv, V_tv,
                  g_tv, G_tv, W_tv,
                  m0, C0);
@@ -327,7 +327,7 @@ void dlm_lp(int n, int r, int p,
                 vector[] b, matrix[] F, vector[] V,
                 vector[] g, matrix[] G, matrix[] W,
                 vector m0, matrix C0) {
-  increment_log_prob(dlm_log(n, r, p, y, miss, b, F, V, g, G, W, m0, C0));
+  target += dlm_logpdf(n, r, p, y, miss, b, F, V, g, G, W, m0, C0);
 }
 
 
@@ -343,12 +343,12 @@ void dlm_constant_lp(int n, int r, int p,
   matrix[p, p] G_tv[n];
   matrix[p, p] W_tv[n];
 
-  b_tv <- rep_array(b, n);
-  F_tv <- rep_array(F, n);
-  V_tv <- rep_array(V, n);  
-  g_tv <- rep_array(g, n);
-  G_tv <- rep_array(G, n);
-  W_tv <- rep_array(W, n);  
+  b_tv = rep_array(b, n);
+  F_tv = rep_array(F, n);
+  V_tv = rep_array(V, n);  
+  g_tv = rep_array(g, n);
+  G_tv = rep_array(G, n);
+  W_tv = rep_array(W, n);  
   dlm_lp(n, r, p, y, miss,
          b_tv, F_tv, V_tv,
          g_tv, G_tv, W_tv,
@@ -358,7 +358,7 @@ void dlm_constant_lp(int n, int r, int p,
 
 vector dlm_get_m(int t, int r, int p, vector[] v) {
   vector[p] x;
-  x <- segment(v[t + 1], 1, p);
+  x = segment(v[t + 1], 1, p);
   return x;
 }
 
@@ -366,7 +366,7 @@ vector dlm_get_m(int t, int r, int p, vector[] v) {
 vector[] dlm_get_m_all(int n, int r, int p, vector[] v) {
   vector[p] res[n + 1];
   for (t in 0:n) {
-    res[t + 1] <- dlm_get_m(t, r, p, v);
+    res[t + 1] = dlm_get_m(t, r, p, v);
   }
   return res;
 }
@@ -375,8 +375,8 @@ vector[] dlm_get_m_all(int n, int r, int p, vector[] v) {
 matrix dlm_get_C(int t, int r, int p, vector[] v) {
   vector[p * p] x;
   matrix[p, p] res;
-  x <- segment(v[t + 1], p + 1, p * p);
-  res <- to_matrix_wdim(x, p, p);
+  x = segment(v[t + 1], p + 1, p * p);
+  res = to_matrix_wdim(x, p, p);
   return res;
 }
 
@@ -384,7 +384,7 @@ matrix dlm_get_C(int t, int r, int p, vector[] v) {
 matrix[] dlm_get_C_all(int n, int r, int p, vector[] v) {
   matrix[p, p] res[n + 1];
   for (t in 0:n) {
-    res[t + 1] <- dlm_get_C(t, r, p, v);
+    res[t + 1] = dlm_get_C(t, r, p, v);
   }
   return res;
 }
@@ -392,7 +392,7 @@ matrix[] dlm_get_C_all(int n, int r, int p, vector[] v) {
 
 vector dlm_get_a(int t, int r, int p, vector[] v) {
   vector[p] res;
-  res <- segment(v[t + 1], p + p * p + 1, p);
+  res = segment(v[t + 1], p + p * p + 1, p);
   return res;
 }
 
@@ -400,7 +400,7 @@ vector dlm_get_a(int t, int r, int p, vector[] v) {
 vector[] dlm_get_a_all(int n, int r, int p, vector[] v) {
   vector[p] res[n];
   for (t in 1:n) {
-    res[t] <- dlm_get_a(t, r, p, v);
+    res[t] = dlm_get_a(t, r, p, v);
   }
   return res;
 }
@@ -409,8 +409,8 @@ vector[] dlm_get_a_all(int n, int r, int p, vector[] v) {
 matrix dlm_get_R(int t, int r, int p, vector[] v) {
   vector[p * p] x;
   matrix[p, p] res;
-  x <- segment(v[t + 1], 2 * p + p * p + 1, p * p);
-  res <- to_matrix_wdim(x, p, p);
+  x = segment(v[t + 1], 2 * p + p * p + 1, p * p);
+  res = to_matrix_wdim(x, p, p);
   return res;
 }
 
@@ -418,7 +418,7 @@ matrix dlm_get_R(int t, int r, int p, vector[] v) {
 matrix[] dlm_get_R_all(int n, int r, int p, vector[] v) {
   matrix[p, p] res[n];
   for (t in 1:n) {
-    res[t] <- dlm_get_R(t, r, p, v);
+    res[t] = dlm_get_R(t, r, p, v);
   }
   return res;
 }
@@ -426,7 +426,7 @@ matrix[] dlm_get_R_all(int n, int r, int p, vector[] v) {
 
 vector dlm_get_e(int t, int r, int p, vector[] v) {
   vector[r] res;
-  res <- segment(v[t + 1], 2 * p + 2 * p * p + 1, r);
+  res = segment(v[t + 1], 2 * p + 2 * p * p + 1, r);
   return res;
 }
 
@@ -434,7 +434,7 @@ vector dlm_get_e(int t, int r, int p, vector[] v) {
 vector[] dlm_get_e_all(int n, int r, int p, vector[] v) {
   vector[r] res[n];
   for (t in 1:n) {
-    res[t] <- dlm_get_e(t, r, p, v);
+    res[t] = dlm_get_e(t, r, p, v);
   }
   return res;
 }
@@ -442,7 +442,7 @@ vector[] dlm_get_e_all(int n, int r, int p, vector[] v) {
 
 vector dlm_get_Q_inv(int t, int r, int p, vector[] v) {
   vector[r] res;
-  res <- segment(v[t + 1], 2 * p + 2 * p * p + r + 1, r);
+  res = segment(v[t + 1], 2 * p + 2 * p * p + r + 1, r);
   return res;
 }
 
@@ -450,7 +450,7 @@ vector dlm_get_Q_inv(int t, int r, int p, vector[] v) {
 vector[] dlm_get_Q_inv_all(int n, int r, int p, vector[] v) {
   vector[r] res[n];
   for (t in 1:n) {
-    res[t] <- dlm_get_Q_inv(t, r, p, v);
+    res[t] = dlm_get_Q_inv(t, r, p, v);
   }
   return res;
 }
@@ -460,13 +460,13 @@ vector[] dlm_filter_loglik(int n, int r, int p, vector[] v, int[,] miss) {
   vector[r] err;
   vector[r] Q_inv;
   for (i in 1:n) {
-    err <- dlm_get_e(i, r, p, v);
-    Q_inv <- dlm_get_Q_inv(i, r, p, v);
+    err = dlm_get_e(i, r, p, v);
+    Q_inv = dlm_get_Q_inv(i, r, p, v);
     for (j in 1:r) {
       if (int_step(miss[i, j])) {
-        ll[i, j] <- 0.0;
+        ll[i, j] = 0.0;
       } else {
-        ll[i, j] <-  - 0.5 * (log(2 * pi()) - log(Q_inv[j]) + (err[j] ^ 2) * Q_inv[j]);
+        ll[i, j] =  - 0.5 * (log(2 * pi()) - log(Q_inv[j]) + (err[j] ^ 2) * Q_inv[j]);
       }
     }
   }
@@ -498,14 +498,14 @@ vector[] dlm_bsample_rng(int n, int p,
   // TODO: sample once and cholesky transform
 
   // set last state
-  theta[n + 1] <- multi_normal_rng(m[n + 1], C[n + 1]);
+  theta[n + 1] = multi_normal_rng(m[n + 1], C[n + 1]);
   for (i in 0:(n - 1)) {
      int t;
-     t <- n - i;
-     R_inv <- inverse(R[t]);
-     h <- m[t] + C[t] * G[t] ' * R_inv  * (theta[t + 1] - a[t]);
-     H <- make_symmetric_matrix(C[t] - C[t] * quad_form(R_inv, G[t]) * C[t]);
-     theta[t] <- multi_normal_rng(h, H);
+     t = n - i;
+     R_inv = inverse(R[t]);
+     h = m[t] + C[t] * G[t] ' * R_inv  * (theta[t + 1] - a[t]);
+     H = make_symmetric_matrix(C[t] - C[t] * quad_form(R_inv, G[t]) * C[t]);
+     theta[t] = multi_normal_rng(h, H);
   }
   return theta;
 }
@@ -525,22 +525,22 @@ vector[] dlm_filter_bsample_rng(int n, int r, int p,
 
   // TODO: sample once and cholesky transform
   // set last state
-  m <- dlm_get_m(n, r, p, v);
-  C <- dlm_get_C(n, r, p, v);
-  theta[n + 1] <- multi_normal_rng(m, C);
+  m = dlm_get_m(n, r, p, v);
+  C = dlm_get_C(n, r, p, v);
+  theta[n + 1] = multi_normal_rng(m, C);
   for (i in 1:n) {
      int t;
-     t <- n - i;
-     m <- dlm_get_m(t, r, p, v);
-     C <- dlm_get_C(t, r, p, v);
-     a <- dlm_get_a(t + 1, r, p, v);
-     R <- dlm_get_R(t + 1, r, p, v);
-     G_t <- G[t + 1];
+     t = n - i;
+     m = dlm_get_m(t, r, p, v);
+     C = dlm_get_C(t, r, p, v);
+     a = dlm_get_a(t + 1, r, p, v);
+     R = dlm_get_R(t + 1, r, p, v);
+     G_t = G[t + 1];
 
-     R_inv <- inverse(R);
-     h <- m + C * G_t ' * R_inv  * (theta[t + 2] - a);
-     H <- make_symmetric_matrix(C - C * quad_form(R_inv, G_t) * C);
-     theta[t + 1] <- multi_normal_rng(h, H);
+     R_inv = inverse(R);
+     h = m + C * G_t ' * R_inv  * (theta[t + 2] - a);
+     H = make_symmetric_matrix(C - C * quad_form(R_inv, G_t) * C);
+     theta[t + 1] = multi_normal_rng(h, H);
   }
   return theta;
 }
@@ -560,27 +560,27 @@ vector[] dlm_smooth(int n, int p,
   vector[p * p + p] ret[n + 1];
 
   // set last state
-  s <- m[n + 1];
-  S <- C[n + 1]; 
+  s = m[n + 1];
+  S = C[n + 1]; 
   for (i in 1:p) {
-    ret[n + 1, i] <- s[i];
+    ret[n + 1, i] = s[i];
   }
-  S_vec <- to_vector(S);
+  S_vec = to_vector(S);
   for (i in 1:(p * p)) {
-    ret[n + 1, p + i] <- S_vec[i];
+    ret[n + 1, p + i] = S_vec[i];
   }
   for (i in 0:(n - 1)) {
      int t;
-     t <- n - i;
-     R_inv <- inverse(R[t]);
-     s <- m[t] + C[t] * G[t] ' * R_inv  * (s - a[t]);
-     S <- make_symmetric_matrix(C[t] - C[t] * G[t] ' * (R[t] - S) * R_inv * G[t] * C[t]);
+     t = n - i;
+     R_inv = inverse(R[t]);
+     s = m[t] + C[t] * G[t] ' * R_inv  * (s - a[t]);
+     S = make_symmetric_matrix(C[t] - C[t] * G[t] ' * (R[t] - S) * R_inv * G[t] * C[t]);
      for (j in 1:p) {
-       ret[t, j] <- s[i];
+       ret[t, j] = s[i];
      }
-     S_vec <- to_vector(S);
+     S_vec = to_vector(S);
      for (j in 1:(p * p)) {
-       ret[t, p + j] <- S_vec[i];
+       ret[t, p + j] = S_vec[i];
      }
   }
   return ret;
@@ -588,14 +588,14 @@ vector[] dlm_smooth(int n, int p,
 
 vector dlm_smooth_get_s(int t, int p, vector[] v) {
   vector[p] ret;
-  ret <- segment(v[t + 1], 1, p);
+  ret = segment(v[t + 1], 1, p);
   return ret;
 }
 
 vector[] dlm_smooth_get_s_all(int n, int p, vector[] v) {
   vector[p] ret[n + 1];
   for (t in 0:n) {
-     ret[t + 1] <- dlm_smooth_get_s(t, p, v);
+     ret[t + 1] = dlm_smooth_get_s(t, p, v);
   }
   return ret;
 }
@@ -603,15 +603,15 @@ vector[] dlm_smooth_get_s_all(int n, int p, vector[] v) {
 matrix dlm_smooth_get_S(int t, int p, vector[] v) {
   vector[p * p] x;
   matrix[p, p] res;
-  x <- segment(v[t + 1], p + 1, p * p);
-  res <- to_matrix_wdim(x, p, p);
+  x = segment(v[t + 1], p + 1, p * p);
+  res = to_matrix_wdim(x, p, p);
   return res;
 }
 
 matrix[] dlm_smooth_get_S_all(int n, int p, vector[] v) {
   matrix[p, p] res[n + 1];
   for (t in 0:n) {
-    res[t + 1] <- dlm_smooth_get_S(t, p, v);
+    res[t + 1] = dlm_smooth_get_S(t, p, v);
   }
   return res;
 }
@@ -644,63 +644,63 @@ vector[] dlm_discount_filter(int n, int r, int p,
   vector[p * p] C_vec;
   vector[p * p] R_vec;
 
-  m <- m0;
-  C <- C0;
-  res[1] <- rep_vector(0.0, dlm_filter_return_size(r, p));
+  m = m0;
+  C = C0;
+  res[1] = rep_vector(0.0, dlm_filter_return_size(r, p));
   for(i in 1:p) {
-    res[1, i] <- m[i];
+    res[1, i] = m[i];
   }
-  C_vec <- to_vector(C);
+  C_vec = to_vector(C);
   for (i in 1:(p * p)) {
-    res[1, p + i] <- C_vec[i];
+    res[1, p + i] = C_vec[i];
   }
   for (t in 1:n) {
     // PREDICT STATES
     // one step ahead predictive distribion of p(\theta_t | y_{1:(t-1)})
-    a <- g[t] + G[t] * m;
-    R <- diag_pre_multiply(1.0 ./ d[t], quad_form(C, G[t] '));
-    m <- a;
-    C <- R;
+    a = g[t] + G[t] * m;
+    R = diag_pre_multiply(1.0 ./ d[t], quad_form(C, G[t] '));
+    m = a;
+    C = R;
     for (j in 1:r) {
       if (int_step(miss[t, j])) {
-        e[j] <- 0.0;
-        Q_inv[j] <- 0.0;
+        e[j] = 0.0;
+        Q_inv[j] = 0.0;
       } else {
         // PREDICT OBS
         // one step ahead predictive distribion of p(y_t | y_{1:(t-1)})
-        Fj <- F[t, j] ';
-        f <- b[t, j] + dot_product(Fj, m);
-        Q <- quad_form(C, Fj) + V[t, j];
-        Q_inv[j] <- 1.0 / Q;
+        Fj = F[t, j] ';
+        f = b[t, j] + dot_product(Fj, m);
+        Q = quad_form(C, Fj) + V[t, j];
+        Q_inv[j] = 1.0 / Q;
         // forecast error
-        e[j] <- y[t, j] - f;
+        e[j] = y[t, j] - f;
         // Kalman gain
-        K <- C * Fj * Q_inv[j];
+        K = C * Fj * Q_inv[j];
         // FILTER STATES
         // posterior distribution of p(\theta_t | y_{1:t})
-        m <- m + K * e[j];
-        C <- make_symmetric_matrix(C - K * Q * K ');
+        m = m + K * e[j];
+        C = make_symmetric_matrix(C - K * Q * K ');
       }
     }
     for(i in 1:p) {
-      res[t + 1, i] <- m[i];
+      res[t + 1, i] = m[i];
     }
-    C_vec <- to_vector(C);
+    C_vec = to_vector(C);
     for (i in 1:(p * p)) {
-      res[t + 1, p + i] <- C_vec[i];
+      res[t + 1, p + i] = C_vec[i];
     }
     for(i in 1:p) {
-      res[t + 1, p + p * p + i] <- a[i];
+      res[t + 1, p + p * p + i] = a[i];
     }
-    R_vec <- to_vector(R);
+    R_vec = to_vector(R);
     for (i in 1:(p * p)) {
-      res[t + 1, 2 * p + p * p + i] <- R_vec[i];
+      res[t + 1, 2 * p + p * p + i] = R_vec[i];
     }
     for (i in 1:r) {
-      res[t + 1, 2 * p + 2 * p * p + i] <- e[i];
+      res[t + 1, 2 * p + 2 * p * p + i] = e[i];
     }
     for (i in 1:r) {
-      res[t + 1, 2 * p + 2 * p * p + r + i] <- Q_inv[i];
+      res[t + 1, 2 * p + 2 * p * p + r + i] = Q_inv[i];
     }
   }
   return res;
@@ -730,41 +730,41 @@ vector[] dlm_discount_loglik(int n, int r, int p,
   // Loglik
   vector[r] loglik[n];
 
-  m <- m0;
-  C <- C0;
+  m = m0;
+  C = C0;
   for (t in 1:n) {
     // PREDICT STATES
     // one step ahead predictive distribion of p(\theta_t | y_{1:(t-1)})
-    a <- g[t] + G[t] * m;
-    R <- diag_pre_multiply(1.0 ./ d[t], quad_form(C, G[t] '));
-    m <- a;
-    C <- R;
+    a = g[t] + G[t] * m;
+    R = diag_pre_multiply(1.0 ./ d[t], quad_form(C, G[t] '));
+    m = a;
+    C = R;
     for (j in 1:r) {
       if (int_step(miss[t, j])) {
-        loglik[t, j] <- 0.0;
+        loglik[t, j] = 0.0;
       } else {
         // PREDICT OBS
         // one step ahead predictive distribion of p(y_t | y_{1:(t-1)})
-        Fj <- F[t, j] ';
-        f <- b[t, j] + dot_product(Fj, m);
-        Q <- quad_form(C, Fj) + V[t, j];
-        Q_inv <- 1.0 / Q;
+        Fj = F[t, j] ';
+        f = b[t, j] + dot_product(Fj, m);
+        Q = quad_form(C, Fj) + V[t, j];
+        Q_inv = 1.0 / Q;
         // forecast error
-        e <- y[t, j] - f;
+        e = y[t, j] - f;
         // Kalman gain
-        K <- C * Fj * Q_inv;
+        K = C * Fj * Q_inv;
         // FILTER STATES
         // posterior distribution of p(\theta_t | y_{1:t})
-        m <- m + K * e;
-        C <- make_symmetric_matrix(C - K * Q * K ');
-        loglik[t, j] <- - 0.5 * (log(2 * pi()) + log(Q) + e ^ 2 * Q_inv);
+        m = m + K * e;
+        C = make_symmetric_matrix(C - K * Q * K ');
+        loglik[t, j] = - 0.5 * (log(2 * pi()) + log(Q) + e ^ 2 * Q_inv);
       }
     }
   }
   return loglik;
 }
 
-real dlm_discount_log(int n, int r, int p, 
+real dlm_discount_logpdf(int n, int r, int p, 
                 vector[] y, int[,] miss,
                 vector[] b, matrix[] F, vector[] V,
                 vector[] g, matrix[] G, vector[] d,
@@ -772,14 +772,14 @@ real dlm_discount_log(int n, int r, int p,
   vector[r] llall[n];
   vector[n] llobs;
   real ll;
-  llall <- dlm_discount_loglik(n, r, p, y, miss,
+  llall = dlm_discount_loglik(n, r, p, y, miss,
                                b, F, V,
                                g, G, d,
                                m0, C0);
   for (i in 1:n) {
-    llobs[i] <- sum(llall[i]);
+    llobs[i] = sum(llall[i]);
   }
-  ll <- sum(llobs);
+  ll = sum(llobs);
   return ll;
 }
 
@@ -789,7 +789,7 @@ void dlm_discount_lp(int n, int r, int p,
                 vector[] b, matrix[] F, vector[] V,
                 vector[] g, matrix[] G, vector[] d,
                 vector m0, matrix C0) {
-  increment_log_prob(dlm_discount_log(n, r, p, y, miss, b, F, V, g, G, d, m0, C0));
+  target += dlm_discount_logpdf(n, r, p, y, miss, b, F, V, g, G, d, m0, C0);
 }
 
 
@@ -817,42 +817,42 @@ vector[] dlm_local_level_filter(int n,
   // returned data
   vector[dlm_filter_return_size(1, 1)] res[n + 1];
 
-  m <- m0;
-  C <- C0;
-  res[1] <- rep_vector(0.0, dlm_filter_return_size(1, 1));
-  res[1, 1] <- m;
-  res[1, 2] <- C;
+  m = m0;
+  C = C0;
+  res[1] = rep_vector(0.0, dlm_filter_return_size(1, 1));
+  res[1, 1] = m;
+  res[1, 2] = C;
   for (t in 1:n) {
     // PREDICT STATES
     // one step ahead predictive distribion of p(\theta_t | y_{1:(t-1)})
-    a <- m;
-    R <- C + W[t];
-    m <- a;
-    C <- R;
+    a = m;
+    R = C + W[t];
+    m = a;
+    C = R;
     if (int_step(miss[t])) {
-      e <- 0.0;
-      Q_inv <- 0.0;
+      e = 0.0;
+      Q_inv = 0.0;
     } else {
       // PREDICT OBS
       // one step ahead predictive distribion of p(y_t | y_{1:(t-1)})
-      f <- m;
-      Q <- C + V[t];
-      Q_inv <- 1.0 / Q;
+      f = m;
+      Q = C + V[t];
+      Q_inv = 1.0 / Q;
       // forecast error
-      e <- y[t] - f;
+      e = y[t] - f;
       // Kalman gain
-      K <- C * Q_inv;
+      K = C * Q_inv;
       // FILTER STATES
       // posterior distribution of p(\theta_t | y_{1:t})
-      m <- m + K * e;
-      C <- C - pow(K, 2) * Q;
+      m = m + K * e;
+      C = C - pow(K, 2) * Q;
     }
-    res[t + 1, 1] <- m;
-    res[t + 1, 2] <- C;
-    res[t + 1, 3] <- a;
-    res[t + 1, 4] <- R;
-    res[t + 1, 5] <- e;
-    res[t + 1, 6] <- Q_inv;
+    res[t + 1, 1] = m;
+    res[t + 1, 2] = C;
+    res[t + 1, 3] = a;
+    res[t + 1, 4] = R;
+    res[t + 1, 5] = e;
+    res[t + 1, 6] = Q_inv;
   }
   return res;
 }
@@ -878,33 +878,33 @@ vector dlm_local_level_loglik(int n,
   // returned data
   vector[n] loglik;
 
-  m <- m0;
-  C <- C0;
+  m = m0;
+  C = C0;
   for (t in 1:n) {
     // PREDICT STATES
     // one step ahead predictive distribion of p(\theta_t | y_{1:(t-1)})
-    a <- m;
-    R <- C + W[t];
-    m <- a;
-    C <- R;
+    a = m;
+    R = C + W[t];
+    m = a;
+    C = R;
     if (int_step(miss[t])) {
-      e <- 0.0;
-      Q_inv <- 0.0;
+      e = 0.0;
+      Q_inv = 0.0;
     } else {
       // PREDICT OBS
       // one step ahead predictive distribion of p(y_t | y_{1:(t-1)})
-      f <- m;
-      Q <- C + V[t];
-      Q_inv <- 1.0 / Q;
+      f = m;
+      Q = C + V[t];
+      Q_inv = 1.0 / Q;
       // forecast error
-      e <- y[t] - f;
+      e = y[t] - f;
       // Kalman gain
-      K <- C * Q_inv;
+      K = C * Q_inv;
       // FILTER STATES
       // posterior distribution of p(\theta_t | y_{1:t})
-      m <- m + K * e;
-      C <- C - pow(K, 2) *  Q;
-      loglik[t] <- - 0.5 * (log(2 * pi()) + log(Q) + pow(e, 2) * Q_inv);
+      m = m + K * e;
+      C = C - pow(K, 2) *  Q;
+      loglik[t] = - 0.5 * (log(2 * pi()) + log(Q) + pow(e, 2) * Q_inv);
     }
   }
   return loglik;
@@ -915,12 +915,12 @@ vector dlm_local_level_filter_loglik(int n, vector[] v, int[] miss) {
   vector[1] err;
   vector[1] Q_inv;
   for (i in 1:n) {
-    err <- dlm_get_e(i, 1, 1, v);
-    Q_inv <- dlm_get_Q_inv(i, 1, 1, v);
+    err = dlm_get_e(i, 1, 1, v);
+    Q_inv = dlm_get_Q_inv(i, 1, 1, v);
     if (int_step(miss[i])) {
-      ll[i] <- 0.0;
+      ll[i] = 0.0;
     } else {
-      ll[i] <-  - 0.5 * (log(2 * pi()) - log(Q_inv[1]) + (err[1] ^ 2) * Q_inv[1]);
+      ll[i] =  - 0.5 * (log(2 * pi()) - log(Q_inv[1]) + (err[1] ^ 2) * Q_inv[1]);
     }
   }
   return ll;
@@ -933,7 +933,7 @@ real dlm_local_level_log(int n,
                          vector V, vector W,
                          real m0, real C0) {
   real ll;
-  ll <- sum(dlm_local_level_loglik(n, y, miss,
+  ll = sum(dlm_local_level_loglik(n, y, miss,
                                    V, W, m0, C0));
   return ll;
 }
@@ -942,8 +942,8 @@ void dlm_local_level_lp(int n,
                           vector y, int[] miss,
                           vector V, vector W,
                           real m0, real C0) {
-  increment_log_prob(dlm_local_level_loglik(n, y, miss,
-                                            V, W, m0, C0));
+  target += dlm_local_level_loglik(n, y, miss,
+                                            V, W, m0, C0);
                                             
 }
 


### PR DESCRIPTION
Resolving the latest rsan's warnings

Please forgive me a sudden Pull Request.

Rstan 2.14.1 complains some warnings for the original your code...
https://github.com/jrnold/dlm-shrinkage/blob/master/stan/includes/dlm.stan

So I propose the following changes.

1. User-defined function's name with _log suffix
 OLD: dlm_xxx_log()
 NEW: dlm_xxx_logpdf()

2. Increment notation for target log density
 OLD: increment_log_prob(u)
 NEW: target += u

3. Assignment operator
 OLD: <-
 NEW:  =

 Please confirm the above.